### PR TITLE
feat(fairs): agregar funcionalidad de archivar/desarchivar ferias

### DIFF
--- a/src/Modules/Fairs/Components/FairsList.tsx
+++ b/src/Modules/Fairs/Components/FairsList.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useFairs, useUpdateFairStatus } from '../Services/FairsServices';
+import { useFairs, useUpdateFairStatus, useUpdateFairArchived } from '../Services/FairsServices';
 import EditFairButton from './EditFairButton';
 import StandsInfoButton from './StandsInfoButton';
 import ConfirmationModal from './ConfirmationModal';
@@ -15,6 +15,7 @@ interface Fair {
   typeFair: string;
   stand_capacity: number;
   status: boolean;
+  archived: boolean;
   date: string;
 }
 
@@ -26,13 +27,18 @@ interface FairsListProps {
 const FairsList = ({ searchTerm = '', statusFilter = 'all' }: FairsListProps) => {
   const { data: fairs, isLoading, error } = useFairs();
   const updateStatus = useUpdateFairStatus();
-  
+  const updateArchived = useUpdateFairArchived();
+
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 9;
 
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [fairToToggle, setFairToToggle] = useState<Fair | null>(null);
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+
+  const [showArchiveModal, setShowArchiveModal] = useState(false);
+  const [fairToArchive, setFairToArchive] = useState<Fair | null>(null);
+  const [isUpdatingArchived, setIsUpdatingArchived] = useState(false);
 
   const [showDetailsModal, setShowDetailsModal] = useState(false);
   const [selectedFair, setSelectedFair] = useState<Fair | null>(null);
@@ -63,6 +69,34 @@ const FairsList = ({ searchTerm = '', statusFilter = 'all' }: FairsListProps) =>
   const cancelToggleStatus = () => {
     setShowConfirmationModal(false);
     setFairToToggle(null);
+  };
+
+  const handleToggleArchiveClick = (fair: Fair) => {
+    setFairToArchive(fair);
+    setShowArchiveModal(true);
+  };
+
+  const confirmToggleArchive = async () => {
+    if (!fairToArchive) return;
+
+    setIsUpdatingArchived(true);
+    try {
+      await updateArchived.mutateAsync({
+        id_fair: fairToArchive.id_fair,
+        archived: !fairToArchive.archived,
+      });
+      setShowArchiveModal(false);
+      setFairToArchive(null);
+    } catch (error) {
+      console.error('Error actualizando el estado de archivo de la feria:', error);
+    } finally {
+      setIsUpdatingArchived(false);
+    }
+  };
+
+  const cancelToggleArchive = () => {
+    setShowArchiveModal(false);
+    setFairToArchive(null);
   };
 
   const handleViewDetails = (fair: Fair) => {
@@ -307,6 +341,23 @@ const FairsList = ({ searchTerm = '', statusFilter = 'all' }: FairsListProps) =>
         isLoading={isUpdatingStatus}
       />
 
+      {/* Modal de Confirmación de Archivo */}
+      <ConfirmationModal
+        show={showArchiveModal}
+        onClose={cancelToggleArchive}
+        onConfirm={confirmToggleArchive}
+        title={fairToArchive?.archived ? "¿Desarchivar feria?" : "¿Archivar feria?"}
+        message={
+          fairToArchive?.archived
+            ? `¿Estás seguro de que deseas desarchivar la feria "${fairToArchive?.name}"? Volverá a estar visible en la lista principal.`
+            : `¿Estás seguro de que deseas archivar la feria "${fairToArchive?.name}"? Dejará de mostrarse en la lista principal.`
+        }
+        confirmText={fairToArchive?.archived ? "Sí, desarchivar" : "Sí, archivar"}
+        cancelText="Cancelar"
+        type={fairToArchive?.archived ? "info" : "warning"}
+        isLoading={isUpdatingArchived}
+      />
+
       {/* Modal de Detalles Completos */}
       <GenericModal
         show={showDetailsModal}
@@ -515,6 +566,29 @@ const FairsList = ({ searchTerm = '', statusFilter = 'all' }: FairsListProps) =>
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
                       </svg>
                       {fair.status ? 'Desactivar' : 'Activar'}
+                    </>
+                  )}
+                </button>
+
+                <button
+                  onClick={() => handleToggleArchiveClick(fair)}
+                  disabled={updateArchived.isPending}
+                  className={`fairs-list__archive-btn ${fair.archived ? 'fairs-list__archive-btn--unarchive' : ''} ${updateArchived.isPending ? 'fairs-list__archive-btn--loading' : ''}`}
+                >
+                  {updateArchived.isPending ? (
+                    <>
+                      <svg className="fairs-list__toggle-spinner" fill="none" viewBox="0 0 24 24">
+                        <circle style={{ opacity: 0.25 }} cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path style={{ opacity: 0.75 }} fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      Actualizando...
+                    </>
+                  ) : (
+                    <>
+                      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                      </svg>
+                      {fair.archived ? 'Desarchivar' : 'Archivar'}
                     </>
                   )}
                 </button>

--- a/src/Modules/Fairs/Services/FairsServices.ts
+++ b/src/Modules/Fairs/Services/FairsServices.ts
@@ -30,6 +30,7 @@ export interface Fair {
   typeFair: string;
   stand_capacity: number;
   status: boolean;
+  archived: boolean;
   date: string;
   datefairs?: FairDate[];
 }
@@ -233,6 +234,19 @@ export const useUpdateFairStatus = () => {
   });
 };
 
+export const useUpdateFairArchived = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id_fair, archived }: { id_fair: number; archived: boolean }) => {
+      const res = await client.patch(`/fairs/${id_fair}/archive`, { archived });
+      return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['fairs'] });
+    },
+  });
+};
+
 export const useFairEnrollments = () => {
   return useQuery<FairEnrollment[], Error>({
     queryKey: ['fair-enrollments'],
@@ -301,7 +315,7 @@ export async function getActiveFairsPublic(): Promise<PublicFair[]> {
     const { data } = await client.get<PublicFair[] | { data: PublicFair[] }>('/fairs');
     const list = Array.isArray(data) ? data : (data as any)?.data ?? [];
 
-    const onlyActive = list.filter((f: any) => f?.status === true);
+    const onlyActive = list.filter((f: any) => f?.status === true && !f?.archived);
 
     const normalized = onlyActive.map((f: any) => {
       const df: FairDate[] =

--- a/src/Modules/Fairs/Styles/FairsList.css
+++ b/src/Modules/Fairs/Styles/FairsList.css
@@ -411,6 +411,50 @@
   to { transform: rotate(360deg); }
 }
 
+.fairs-list__archive-btn {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: medium;
+  border-radius: 0.5rem;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+  background-color: #fef3c7;
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
+.fairs-list__archive-btn:hover {
+  background-color: #fde68a;
+  border-color: #fbbf24;
+}
+
+.fairs-list__archive-btn--unarchive {
+  background-color: #dbeafe;
+  border-color: #93c5fd;
+  color: #1e40af;
+}
+
+.fairs-list__archive-btn--unarchive:hover {
+  background-color: #bfdbfe;
+  border-color: #60a5fa;
+}
+
+.fairs-list__archive-btn--loading {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fairs-list__archive-btn svg {
+  height: 1rem;
+  width: 1rem;
+  margin-right: 0.5rem;
+}
+
 .fairs-list__details-modal {
   display: flex;
   flex-direction: column;
@@ -821,4 +865,4 @@
     min-width: 100px;
     justify-content: center;
   }
-}
+}


### PR DESCRIPTION
- Agrega campo archived a la interfaz Fair en el servicio del frontend
- Agrega hook useUpdateFairArchived que consume PATCH /fairs/:id/archive
- Agrega botón de archivar/desarchivar en cada tarjeta de la lista administrativa con modal de confirmación
- Agrega estilos dedicados para el botón de archivo
- Filtra ferias archivadas en la vista pública, mostrando solo las activas y no archivadas