### PR TITLE
Mejoras de estilo y UX en formularios de emprendedores

### DIFF
--- a/src/Modules/Donors/Components/AddDonorForm.tsx
+++ b/src/Modules/Donors/Components/AddDonorForm.tsx
@@ -265,6 +265,7 @@ const AddDonorForm: React.FC<AddDonorFormProps> = ({ onSubmit, onCancel }) => {
                 value={formData.phone}
                 onChange={(val) => { setFormData((prev) => ({ ...prev, phone: val })); if (fieldErrors.phone) setFieldErrors(prev => ({ ...prev, phone: '' })); }}
                 error={fieldErrors.phone || (formData.phone && !validatePhone(formData.phone) ? 'El número de teléfono no es válido. Debe incluir código de país (ej: +50688888888)' : undefined)}
+                variant="add"
               />
             </div>
 

--- a/src/Modules/Entrepreneurs/Components/AddEntrepreneurForm.tsx
+++ b/src/Modules/Entrepreneurs/Components/AddEntrepreneurForm.tsx
@@ -487,6 +487,7 @@ const AddEntrepreneurForm = ({ onSuccess }: AddEntrepreneurFormProps) => {
             renderField={renderField}
             form={form}
             fieldErrors={fieldErrors}
+            onClearFieldError={(name) => setFieldErrors(prev => ({ ...prev, [name]: '' }))}
             apiError={apiError}
             onCancel={onSuccess}
           />

--- a/src/Modules/Entrepreneurs/Components/AddEntrepreneurshipDataStep.tsx
+++ b/src/Modules/Entrepreneurs/Components/AddEntrepreneurshipDataStep.tsx
@@ -1,8 +1,9 @@
-import { ENTREPRENEURSHIP_CATEGORIES, ENTREPRENEURSHIP_APPROACHES, type EntrepreneurFormData } from '../Types';
+import { type EntrepreneurFormData } from '../Types';
 import ConsentCheckbox from '../../Shared/components/ConsentCheckbox';
 import '../Styles/AddEntrepreneurForm.css';
 import { useState } from "react";
-import { Store } from 'lucide-react';
+import { Store, CookingPot, Shirt, Palette, House, Drama, Sparkles, Heart, Landmark, Leaf } from 'lucide-react';
+import FormDropdown, { type FormDropdownOption } from './FormDropdown';
 
 interface EntrepreneurshipDataStepProps {
   formValues: EntrepreneurFormData;
@@ -12,6 +13,7 @@ interface EntrepreneurshipDataStepProps {
   renderField: (name: keyof EntrepreneurFormData, config?: any) => React.ReactNode;
   form: any;
   fieldErrors: Record<string, string>;
+  onClearFieldError: (name: string) => void;
   apiError?: string;
   onCancel: () => void;
 }
@@ -20,7 +22,23 @@ const MAX_IMAGE_SIZE_MB = 10;
 const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
 
-const EntrepreneurshipDataStep = ({ onPrevious, onSubmit, isLoading, renderField, form, fieldErrors, apiError, onCancel }: EntrepreneurshipDataStepProps) => {
+const CATEGORY_OPTIONS: FormDropdownOption[] = [
+  { value: 'Comida',        label: 'Comida',         icon: <CookingPot size={16} /> },
+  { value: 'Artesanía',     label: 'Artesanía',      icon: <Palette size={16} /> },
+  { value: 'Vestimenta',    label: 'Vestimenta',     icon: <Shirt size={16} /> },
+  { value: 'Accesorios',    label: 'Accesorios',     icon: <Sparkles size={16} /> },
+  { value: 'Decoración',    label: 'Decoración',     icon: <House size={16} /> },
+  { value: 'Demostración',  label: 'Demostración',   icon: <Drama size={16} /> },
+  { value: 'Otra categoría',label: 'Otra categoría', icon: <Sparkles size={16} /> },
+];
+
+const APPROACH_OPTIONS: FormDropdownOption[] = [
+  { value: 'social',    label: 'Social',    icon: <Heart size={16} /> },
+  { value: 'cultural',  label: 'Cultural',  icon: <Landmark size={16} /> },
+  { value: 'ambiental', label: 'Ambiental', icon: <Leaf size={16} /> },
+];
+
+const EntrepreneurshipDataStep = ({ onPrevious, onSubmit, isLoading, renderField, form, fieldErrors, onClearFieldError, apiError, onCancel }: EntrepreneurshipDataStepProps) => {
 
   const [previews, setPreviews] = useState<{ [key: string]: string | null }>({});
   const [imageErrors, setImageErrors] = useState<{ [key: string]: string }>({});
@@ -74,20 +92,32 @@ const EntrepreneurshipDataStep = ({ onPrevious, onSubmit, isLoading, renderField
         })}
 
         {/* Category */}
-        {renderField('category', {
-          label: 'Categoría',
-          required: true,
-          type: 'select',
-          options: ENTREPRENEURSHIP_CATEGORIES
-        })}
+        <FormDropdown
+          label="Categoría"
+          required
+          variant="add"
+          value={form.state.values.category as string}
+          options={CATEGORY_OPTIONS}
+          onChange={(val) => {
+            form.setFieldValue('category', val as any);
+            onClearFieldError('category');
+          }}
+          error={fieldErrors.category}
+        />
 
         {/* Approach */}
-        {renderField('approach', {
-          label: 'Enfoque',
-          required: true,
-          type: 'select',
-          options: ENTREPRENEURSHIP_APPROACHES.map(approach => approach.value)
-        })}
+        <FormDropdown
+          label="Enfoque"
+          required
+          variant="add"
+          value={form.state.values.approach as string}
+          options={APPROACH_OPTIONS}
+          onChange={(val) => {
+            form.setFieldValue('approach', val as any);
+            onClearFieldError('approach');
+          }}
+          error={fieldErrors.approach}
+        />
 
 
         {/* Imágenes obligatorias */}
@@ -155,6 +185,7 @@ const EntrepreneurshipDataStep = ({ onPrevious, onSubmit, isLoading, renderField
                                 return;
                               }
                               setImageErrors(prev => ({ ...prev, [field]: '' }));
+                              onClearFieldError(field as string);
                               form.setFieldValue(field, file);
                               setPreviews((prev) => ({
                                 ...prev,
@@ -204,6 +235,7 @@ const EntrepreneurshipDataStep = ({ onPrevious, onSubmit, isLoading, renderField
                                 return;
                               }
                               setImageErrors(prev => ({ ...prev, [field]: '' }));
+                              onClearFieldError(field as string);
                               form.setFieldValue(field, file);
                               setPreviews((prev) => ({
                                 ...prev,

--- a/src/Modules/Entrepreneurs/Components/AddPersonalDataStep.tsx
+++ b/src/Modules/Entrepreneurs/Components/AddPersonalDataStep.tsx
@@ -108,12 +108,14 @@ const PersonalDataStep = ({
           value={phonePrimary}
           onChange={onPhonePrimaryChange}
           error={phonePrimaryError}
+          variant="add"
         />
         <PhoneInputField
           label="Teléfono Secundario"
           value={phoneSecondary}
           onChange={onPhoneSecondaryChange}
           error={phoneSecondaryError}
+          variant="add"
         />
 
         {/* Experience */}

--- a/src/Modules/Entrepreneurs/Components/EditEntrepreneurForm.tsx
+++ b/src/Modules/Entrepreneurs/Components/EditEntrepreneurForm.tsx
@@ -17,6 +17,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
   const [isLoading, setIsLoading] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [apiError, setApiError] = useState('');
+  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
   const updateEntrepreneur = useUpdateEntrepreneur(entrepreneur.id_entrepreneur!);
   
   const form = useForm({
@@ -207,7 +208,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
             <div className={config.type === 'url' ? 'edit-entrepreneur-form__file-field' : ''}>
               <label className="edit-entrepreneur-form__label">
                 {label}{' '}
-                {showInitialEditable && !showRequiredText && (
+                {showInitialEditable && !showRequiredText && !touchedFields[name as string] && !disabled && !readOnly && (
                   <span className="edit-entrepreneur-form__initial-editable">valor inicial editable</span>
                 )}
                 {(showRequiredText || (required && initialValue === undefined)) && (
@@ -220,7 +221,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
                   name={field.name}
                   value={(typeof value === 'string' ? value : '') || ''}
                   onBlur={field.handleBlur}
-                  onChange={(e) => { field.handleChange(e.target.value as any); if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' })); }}
+                  onChange={(e) => { field.handleChange(e.target.value as any); setTouchedFields(prev => ({ ...prev, [name as string]: true })); if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' })); }}
                   className="edit-entrepreneur-form__input edit-entrepreneur-form__input--textarea"
                   placeholder={placeholder}
                   required={required}
@@ -234,7 +235,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
                   name={field.name}
                   value={(typeof value === 'string' ? value : '') || ''}
                   onBlur={field.handleBlur}
-                  onChange={(e) => { field.handleChange(e.target.value as any); if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' })); }}
+                  onChange={(e) => { field.handleChange(e.target.value as any); setTouchedFields(prev => ({ ...prev, [name as string]: true })); if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' })); }}
                   className="edit-entrepreneur-form__input edit-entrepreneur-form__input--select"
                   required={required}
                   disabled={disabled}
@@ -279,6 +280,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
                       } else {
                         field.handleChange(e.target.value as any);
                       }
+                      setTouchedFields(prev => ({ ...prev, [name as string]: true }));
                       if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' }));
                     }}
                     className="edit-entrepreneur-form__input edit-entrepreneur-form__input--with-icon"
@@ -305,6 +307,7 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
                     } else {
                       field.handleChange(e.target.value as any);
                     }
+                    setTouchedFields(prev => ({ ...prev, [name as string]: true }));
                     if (fieldErrors[name as string]) setFieldErrors(prev => ({ ...prev, [name as string]: '' }));
                   }}
                   className="edit-entrepreneur-form__input"
@@ -386,6 +389,8 @@ const EditEntrepreneurForm = ({ entrepreneur, onSuccess }: EditEntrepreneurFormP
             form={form}
             errorMessage={apiError}
             onCancel={onSuccess}
+            touchedFields={touchedFields}
+            onTouchField={(name) => setTouchedFields(prev => ({ ...prev, [name]: true }))}
           />
         )}
       </form>

--- a/src/Modules/Entrepreneurs/Components/EditEntrepreneurshipDataStep.tsx
+++ b/src/Modules/Entrepreneurs/Components/EditEntrepreneurshipDataStep.tsx
@@ -1,8 +1,26 @@
-import { ENTREPRENEURSHIP_CATEGORIES, ENTREPRENEURSHIP_APPROACHES, type Entrepreneur, type EntrepreneurUpdateData } from '../Types';
+import { type Entrepreneur, type EntrepreneurUpdateData } from '../Types';
 import { useState, useEffect, useCallback } from 'react';
 import { API_BASE_URL } from '../../../config/env';
 import ConfirmationModal from '../../Fairs/Components/ConfirmationModal';
 import '../Styles/EditEntrepreneurForm.css';
+import { CookingPot, Shirt, Palette, House, Drama, Sparkles, Heart, Landmark, Leaf } from 'lucide-react';
+import FormDropdown, { type FormDropdownOption } from './FormDropdown';
+
+const CATEGORY_OPTIONS: FormDropdownOption[] = [
+  { value: 'Comida',         label: 'Comida',         icon: <CookingPot size={16} /> },
+  { value: 'Artesanía',      label: 'Artesanía',      icon: <Palette size={16} /> },
+  { value: 'Vestimenta',     label: 'Vestimenta',     icon: <Shirt size={16} /> },
+  { value: 'Accesorios',     label: 'Accesorios',     icon: <Sparkles size={16} /> },
+  { value: 'Decoración',     label: 'Decoración',     icon: <House size={16} /> },
+  { value: 'Demostración',   label: 'Demostración',   icon: <Drama size={16} /> },
+  { value: 'Otra categoría', label: 'Otra categoría', icon: <Sparkles size={16} /> },
+];
+
+const APPROACH_OPTIONS: FormDropdownOption[] = [
+  { value: 'social',    label: 'Social',    icon: <Heart size={16} /> },
+  { value: 'cultural',  label: 'Cultural',  icon: <Landmark size={16} /> },
+  { value: 'ambiental', label: 'Ambiental', icon: <Leaf size={16} /> },
+];
 
 const MAX_IMAGE_SIZE_MB = 10;
 const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
@@ -25,6 +43,8 @@ interface EditEntrepreneurshipDataStepProps {
   form: any;
   errorMessage?: string;
   onCancel: () => void;
+  touchedFields: Record<string, boolean>;
+  onTouchField: (name: string) => void;
 }
 
 const EditEntrepreneurshipDataStep = ({
@@ -36,7 +56,9 @@ const EditEntrepreneurshipDataStep = ({
   renderField,
   form,
   errorMessage,
-  onCancel
+  onCancel,
+  touchedFields,
+  onTouchField,
 }: EditEntrepreneurshipDataStepProps) => {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [objectUrls, setObjectUrls] = useState<string[]>([]);
@@ -337,21 +359,29 @@ const getProxyImageUrl = useCallback((url: string): string => {
           initialValue: entrepreneur.entrepreneurship?.location
         })}
 
-        {renderField('category', {
-          label: 'Categoría',
-          required: true,
-          type: 'select',
-          options: ENTREPRENEURSHIP_CATEGORIES,
-          initialValue: entrepreneur.entrepreneurship?.category
-        })}
+        <FormDropdown
+          label="Categoría"
+          variant="edit"
+          value={formValues.category as string || 'Comida'}
+          options={CATEGORY_OPTIONS}
+          showInitialEditable={!touchedFields['category']}
+          onChange={(val) => {
+            form.setFieldValue('category', val as any);
+            onTouchField('category');
+          }}
+        />
 
-        {renderField('approach', {
-          label: 'Enfoque',
-          required: true,
-          type: 'select',
-          options: ENTREPRENEURSHIP_APPROACHES.map((a) => a.value),
-          initialValue: entrepreneur.entrepreneurship?.approach
-        })}
+        <FormDropdown
+          label="Enfoque"
+          variant="edit"
+          value={formValues.approach as string || 'social'}
+          options={APPROACH_OPTIONS}
+          showInitialEditable={!touchedFields['approach']}
+          onChange={(val) => {
+            form.setFieldValue('approach', val as any);
+            onTouchField('approach');
+          }}
+        />
       </div>
 
       <div className="edit-entrepreneur-form__section">

--- a/src/Modules/Entrepreneurs/Components/FormDropdown.tsx
+++ b/src/Modules/Entrepreneurs/Components/FormDropdown.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useRef, useEffect } from 'react';
+import '../Styles/FormDropdown.css';
+
+export interface FormDropdownOption {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface FormDropdownProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: FormDropdownOption[];
+  label: string;
+  required?: boolean;
+  error?: string;
+  disabled?: boolean;
+  variant: 'add' | 'edit';
+  showInitialEditable?: boolean;
+}
+
+const FormDropdown: React.FC<FormDropdownProps> = ({
+  value,
+  onChange,
+  options,
+  label,
+  required = false,
+  error,
+  disabled = false,
+  variant,
+  showInitialEditable = false,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const selectedOption = options.find(opt => opt.value === value);
+  const showRequired = required && !value;
+
+  return (
+    <div className={`form-dropdown form-dropdown--${variant}`} ref={dropdownRef}>
+      <label className="form-dropdown__label">
+        {label}{' '}
+        {showRequired && <span className="form-dropdown__required">*</span>}
+        {showInitialEditable && !showRequired && (
+          <span className="form-dropdown__initial-editable">valor inicial editable</span>
+        )}
+      </label>
+
+      <button
+        type="button"
+        className={[
+          'form-dropdown__trigger',
+          error ? 'form-dropdown__trigger--error' : '',
+          isOpen ? 'form-dropdown__trigger--open' : '',
+        ].filter(Boolean).join(' ')}
+        onClick={() => { if (!disabled) setIsOpen(prev => !prev); }}
+        disabled={disabled}
+      >
+        <div className="form-dropdown__trigger-content">
+          {selectedOption?.icon && (
+            <span className="form-dropdown__selected-icon">{selectedOption.icon}</span>
+          )}
+          <span className="form-dropdown__selected-text">
+            {selectedOption?.label || 'Seleccionar...'}
+          </span>
+        </div>
+        <div className={`form-dropdown__chevron${isOpen ? ' form-dropdown__chevron--open' : ''}`}>
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="form-dropdown__menu">
+          <div className="form-dropdown__options">
+            {options.map(option => (
+              <button
+                key={option.value}
+                type="button"
+                className={`form-dropdown__option${value === option.value ? ' form-dropdown__option--selected' : ''}`}
+                onClick={() => { onChange(option.value); setIsOpen(false); }}
+              >
+                <div className="form-dropdown__option-content">
+                  {option.icon && (
+                    <span className="form-dropdown__option-icon">{option.icon}</span>
+                  )}
+                  <span className="form-dropdown__option-text">{option.label}</span>
+                </div>
+                {value === option.value && (
+                  <div className="form-dropdown__check">
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {error && <span className="form-dropdown__error">{error}</span>}
+    </div>
+  );
+};
+
+export default FormDropdown;

--- a/src/Modules/Entrepreneurs/Styles/AddEntrepreneurForm.css
+++ b/src/Modules/Entrepreneurs/Styles/AddEntrepreneurForm.css
@@ -11,8 +11,8 @@
   --background-header: #e2e8f0;
   --border-color-light: #d1d5db;
   --border-color-medium: #e5e7eb;
-  --focus-color: #2563eb;
-  --focus-box-shadow: rgba(37, 99, 235, 0.1);
+  --focus-color: #52AC83;
+  --focus-box-shadow: rgba(82, 172, 131, 0.15);
   --border-radius-small: 0.25rem;
   --border-radius-medium: 0.5rem;
   --border-radius-large: 0.75rem;
@@ -214,8 +214,8 @@
 .add-entrepreneur-form__textarea:focus,
 .add-entrepreneur-form__select:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  border-color: #52AC83;
+  box-shadow: 0 0 0 3px rgba(82, 172, 131, 0.15);
   transform: translateY(-1px);
 }
 
@@ -337,7 +337,7 @@
 }
 
 .add-entrepreneur-form__image-upload-box:hover {
-  border-color: #6366f1;
+  border-color: #52AC83;
   background-color: #f3f4f6;
 }
 

--- a/src/Modules/Entrepreneurs/Styles/FormDropdown.css
+++ b/src/Modules/Entrepreneurs/Styles/FormDropdown.css
@@ -1,0 +1,275 @@
+/* ── Color tokens por variante ── */
+.form-dropdown--add {
+  --fd-accent: #52AC83;
+  --fd-accent-shadow: rgba(82, 172, 131, 0.15);
+  --fd-selected-bg: #d1fae5;
+  --fd-selected-color: #52AC83;
+  --fd-hover-bg: #a8f7d3;
+  --fd-check-color: #52AC83;
+}
+
+.form-dropdown--edit {
+  --fd-accent: #2563eb;
+  --fd-accent-shadow: rgba(37, 99, 235, 0.15);
+  --fd-selected-bg: #dbeafe;
+  --fd-selected-color: #2563eb;
+  --fd-hover-bg: #bfdbfe;
+  --fd-check-color: #2563eb;
+}
+
+/* ── Contenedor ── */
+.form-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+/* ── Label ── */
+.form-dropdown__label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.form-dropdown__required {
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.form-dropdown__initial-editable {
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-style: italic;
+  margin-left: 0.25rem;
+}
+
+/* ── Trigger ── */
+.form-dropdown__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 0.875rem;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  color: #374151;
+  font-size: 0.875rem;
+  font-weight: 400;
+  cursor: pointer;
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.form-dropdown__trigger:hover:not(:disabled) {
+  background-color: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.form-dropdown__trigger:focus,
+.form-dropdown__trigger--open {
+  outline: none;
+  border-color: var(--fd-accent);
+  box-shadow: 0 0 0 3px var(--fd-accent-shadow);
+}
+
+.form-dropdown__trigger--error {
+  border-color: #ef4444;
+  background-color: #fef2f2;
+}
+
+.form-dropdown__trigger:disabled {
+  background-color: #f9fafb;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+/* ── Trigger content ── */
+.form-dropdown__trigger-content {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  overflow: hidden;
+}
+
+.form-dropdown__selected-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--fd-accent);
+}
+
+.form-dropdown__selected-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Chevron ── */
+.form-dropdown__chevron {
+  display: flex;
+  align-items: center;
+  color: #9ca3af;
+  flex-shrink: 0;
+  transition: transform 0.2s ease-in-out;
+}
+
+.form-dropdown__chevron--open {
+  transform: rotate(180deg);
+}
+
+.form-dropdown__chevron svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* ── Menú desplegable ── */
+.form-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.form-dropdown__options {
+  padding: 0.25rem 0;
+}
+
+/* ── Opción ── */
+.form-dropdown__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.625rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  color: #374151;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.form-dropdown__option:hover {
+  background-color: var(--fd-hover-bg);
+}
+
+.form-dropdown__option--selected {
+  background-color: var(--fd-selected-bg);
+  color: var(--fd-selected-color);
+  font-weight: 500;
+}
+
+.form-dropdown__option--selected:hover {
+  background-color: var(--fd-hover-bg);
+}
+
+.form-dropdown__option-content {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex: 1;
+}
+
+.form-dropdown__option-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.form-dropdown__option-text {
+  flex: 1;
+}
+
+/* ── Check ── */
+.form-dropdown__check {
+  display: flex;
+  align-items: center;
+  color: var(--fd-check-color);
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.form-dropdown__check svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* ── Error ── */
+.form-dropdown__error {
+  display: block;
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-top: 0.25rem;
+}
+
+/* ── Dark mode ── */
+[data-theme="dark"] .form-dropdown__label { color: #8e8e93; }
+[data-theme="dark"] .form-dropdown__initial-editable { color: #60a5fa; }
+
+[data-theme="dark"] .form-dropdown__trigger {
+  background-color: #1c1c1e;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #f5f5f7;
+}
+
+[data-theme="dark"] .form-dropdown__trigger:hover:not(:disabled) {
+  background-color: #2c2c2e;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+[data-theme="dark"] .form-dropdown__trigger:focus,
+[data-theme="dark"] .form-dropdown__trigger--open {
+  border-color: var(--fd-accent);
+  box-shadow: 0 0 0 3px var(--fd-accent-shadow);
+}
+
+[data-theme="dark"] .form-dropdown__trigger--error {
+  border-color: #f87171;
+  background-color: rgba(239, 68, 68, 0.08);
+}
+
+[data-theme="dark"] .form-dropdown__chevron { color: #6e6e73; }
+
+[data-theme="dark"] .form-dropdown__menu {
+  background-color: #2c2c2e;
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] .form-dropdown__option { color: #d1d1d6; }
+
+[data-theme="dark"] .form-dropdown--add .form-dropdown__option:hover {
+  background-color: rgba(82, 172, 131, 0.15);
+}
+[data-theme="dark"] .form-dropdown--add .form-dropdown__option--selected {
+  background-color: rgba(82, 172, 131, 0.2);
+  color: #52AC83;
+}
+[data-theme="dark"] .form-dropdown--add .form-dropdown__option--selected:hover {
+  background-color: rgba(82, 172, 131, 0.3);
+}
+
+[data-theme="dark"] .form-dropdown--edit .form-dropdown__option:hover {
+  background-color: rgba(37, 99, 235, 0.15);
+}
+[data-theme="dark"] .form-dropdown--edit .form-dropdown__option--selected {
+  background-color: rgba(37, 99, 235, 0.2);
+  color: #60a5fa;
+}
+[data-theme="dark"] .form-dropdown--edit .form-dropdown__option--selected:hover {
+  background-color: rgba(37, 99, 235, 0.3);
+}

--- a/src/Modules/Informative/Public/components/DonationPublicForm.tsx
+++ b/src/Modules/Informative/Public/components/DonationPublicForm.tsx
@@ -300,6 +300,7 @@ export default function DonationPublicForm({ onClose }: Props) {
                   value={phone}
                   onChange={(val) => { setPhone(val); if (phoneError) setPhoneError(''); }}
                   error={phoneError || (phone && !validatePhone(phone) ? 'El número no es válido. Debe incluir código de país (ej: +50688888888).' : undefined)}
+                  variant="add"
                 />
               </div>
 

--- a/src/Modules/Users/Components/AddUserForm.tsx
+++ b/src/Modules/Users/Components/AddUserForm.tsx
@@ -429,6 +429,7 @@ const AddUserForm: React.FC<AddUserFormProps> = ({ onSuccess }) => {
         value={personFormData.phone_primary}
         onChange={(val) => { setPersonFormData(prev => ({ ...prev, phone_primary: val })); if (fieldErrors.phone_primary) setFieldErrors(prev => ({ ...prev, phone_primary: '' })); }}
         error={fieldErrors.phone_primary || (personFormData.phone_primary && !validatePhone(personFormData.phone_primary) ? 'El número de teléfono no es válido.' : undefined)}
+        variant="add"
       />
 
       {/* Teléfono Secundario */}
@@ -441,6 +442,7 @@ const AddUserForm: React.FC<AddUserFormProps> = ({ onSuccess }) => {
             ? 'El número de teléfono no es válido'
             : undefined
         }
+        variant="add"
       />
     </div>
   );

--- a/src/Modules/Volunteers/Components/ActivityEnrollmentPublicForm.tsx
+++ b/src/Modules/Volunteers/Components/ActivityEnrollmentPublicForm.tsx
@@ -484,6 +484,7 @@ export default function ActivityEnrollmentPublicForm({ activityId, activityName,
                   onChange={field.onChange}
                   error={errors.phone?.message}
                   disabled={isVolunteer}
+                  variant="add"
                 />
               )}
             />

--- a/src/Modules/Volunteers/Components/AddVolunteerForm.tsx
+++ b/src/Modules/Volunteers/Components/AddVolunteerForm.tsx
@@ -265,6 +265,7 @@ const AddVolunteerForm = ({ onSuccess }: AddVolunteerFormProps) => {
                     value={field.state.value as string}
                     onChange={(val) => { field.handleChange(val as any); if (fieldErrors.phone_primary) setFieldErrors(prev => ({ ...prev, phone_primary: '' })); }}
                     error={fieldErrors.phone_primary || (field.state.value && !validatePhone(field.state.value as string) ? 'El número de teléfono no es válido.' : undefined)}
+                    variant="add"
                   />
                 )}
               </form.Field>
@@ -280,6 +281,7 @@ const AddVolunteerForm = ({ onSuccess }: AddVolunteerFormProps) => {
                         ? 'El número de teléfono no es válido'
                         : undefined
                     }
+                    variant="add"
                   />
                 )}
               </form.Field>

--- a/src/Modules/Volunteers/Components/VolunteerPublicForm.tsx
+++ b/src/Modules/Volunteers/Components/VolunteerPublicForm.tsx
@@ -385,6 +385,7 @@ export default function VolunteerPublicForm({ onClose }: Props) {
                   value={field.value || ''}
                   onChange={field.onChange}
                   error={errors.phone_personal?.message}
+                  variant="add"
                 />
               )}
             />
@@ -411,6 +412,7 @@ export default function VolunteerPublicForm({ onClose }: Props) {
                   value={field.value || ''}
                   onChange={field.onChange}
                   error={errors.phone_business?.message}
+                  variant="add"
                 />
               )}
             />

--- a/src/shared/components/PhoneInput/PhoneInputField.css
+++ b/src/shared/components/PhoneInput/PhoneInputField.css
@@ -38,8 +38,13 @@
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
 }
 
+.phone-input-field__wrapper--add:focus-within {
+  border-color: #52AC83;
+  box-shadow: 0 0 0 3px rgba(82, 172, 131, 0.15);
+}
+
 .phone-input-field__wrapper--error {
-  border-color: #ef4444;
+  border-color: #d1d5db;
 }
 
 .phone-input-field__wrapper--error:focus-within {
@@ -161,6 +166,11 @@
 [data-theme="dark"] .phone-input-field__wrapper:focus-within {
   border-color: #60a5fa;
   box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+}
+
+[data-theme="dark"] .phone-input-field__wrapper--add:focus-within {
+  border-color: #52AC83;
+  box-shadow: 0 0 0 3px rgba(82, 172, 131, 0.2);
 }
 
 [data-theme="dark"] .phone-input-field__wrapper--error {

--- a/src/shared/components/PhoneInput/PhoneInputField.tsx
+++ b/src/shared/components/PhoneInput/PhoneInputField.tsx
@@ -14,6 +14,7 @@ interface PhoneInputFieldProps {
   placeholder?: string;
   id?: string;
   className?: string;
+  variant?: 'add' | 'edit';
 }
 
 const PhoneInputField: React.FC<PhoneInputFieldProps> = ({
@@ -26,6 +27,7 @@ const PhoneInputField: React.FC<PhoneInputFieldProps> = ({
   placeholder,
   id,
   className = '',
+  variant = 'edit',
 }) => {
   const handleChange = (val: PhoneValue) => {
     onChange(val ?? '');
@@ -33,6 +35,7 @@ const PhoneInputField: React.FC<PhoneInputFieldProps> = ({
 
   const wrapperClass = [
     'phone-input-field__wrapper',
+    variant === 'add' ? 'phone-input-field__wrapper--add' : '',
     error ? 'phone-input-field__wrapper--error' : '',
   ]
     .filter(Boolean)


### PR DESCRIPTION
- Cambiar contorno de inputs de azul a verde en formulario de agregar emprendedor
- Agregar variante de color al PhoneInputField (verde para agregar, azul para editar)
- Implementar comportamiento de valor inicial editable en formulario de editar emprendedor
- Ocultar mensaje de valor inicial editable en campo de correo (no editable)
- Limpiar error de imagen al subirla en formulario de agregar emprendedor
- Reemplazar selects nativos de categoría y enfoque por dropdowns personalizados con íconos
- Quitar contorno rojo del input de teléfono en estado de error